### PR TITLE
Basic Factories: Closes #9

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :politician do
+    sequence :name do |n|
+      "Politician #{n}"
+    end
+    party "D"
+    multiplier 1.5
+    image "some image"
+  end
+
+  factory :outing do
+    sequence :title do |n|
+      "Outing #{n}"
+    end
+    description "some description"
+    base_cost 50
+    image_url "some image"
+    politician
+  end
+end


### PR DESCRIPTION
@Dpalazzari @Laszlo-JFLMTCO @njgheorghita Adds basic factories for politician and outings. I think this should work for the stories that we have so far. By default, it creates a relationship to a politician every time an outing is created. If you need to specify a specific politician we'll have to do that from the tests